### PR TITLE
Add VPC Endpoints

### DIFF
--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -56,7 +56,173 @@ module "vpc" {
     }
   ]
 
+  enable_s3_endpoint       = true
+  enable_dynamodb_endpoint = true
+
+  #  all_interface_endpoints_security_group_ids = []
+
+  # Interface Endpoints will cause additional costs
+
+  # Not supported in us-east-1
+  enable_transferserver_endpoint            = false
+  enable_appstream_endpoint                 = false
+  enable_elasticbeanstalk_health_endpoint   = false
+  enable_transfer_endpoint                  = false
+  enable_elastic_inference_runtime_endpoint = false
+  enable_ses_endpoint                       = false
+
+  enable_codebuild_endpoint             = true
+  codebuild_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_codecommit_endpoint             = true
+  codecommit_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_git_codecommit_endpoint             = true
+  git_codecommit_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_config_endpoint             = true
+  config_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sqs_endpoint             = true
+  sqs_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_secretsmanager_endpoint             = true
+  secretsmanager_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ssm_endpoint             = true
+  ssm_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ssmmessages_endpoint             = true
+  ssmmessages_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ec2_endpoint             = true
+  ec2_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ec2messages_endpoint             = true
+  ec2messages_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_autoscaling_plans_endpoint             = true
+  autoscaling_plans_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ec2_autoscaling_endpoint             = true
+  ec2_autoscaling_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ecr_api_endpoint             = true
+  ecr_api_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ecr_dkr_endpoint             = true
+  ecr_dkr_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_apigw_endpoint             = true
+  apigw_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_kms_endpoint             = true
+  kms_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ecs_endpoint             = true
+  ecs_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ecs_agent_endpoint             = true
+  ecs_agent_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ecs_telemetry_endpoint             = true
+  ecs_telemetry_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sns_endpoint             = true
+  sns_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_monitoring_endpoint             = true
+  monitoring_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_logs_endpoint             = true
+  logs_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_events_endpoint             = true
+  events_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_elasticloadbalancing_endpoint             = true
+  elasticloadbalancing_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_cloudtrail_endpoint             = true
+  cloudtrail_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_kinesis_streams_endpoint             = true
+  kinesis_streams_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_kinesis_firehose_endpoint             = true
+  kinesis_firehose_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_glue_endpoint             = true
+  glue_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sagemaker_notebook_endpoint             = true
+  sagemaker_notebook_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sts_endpoint                = true
+  sts_endpoint_security_group_ids    = [aws_security_group.vpc_interface_endpoints.id]
+  sagemaker_notebook_endpoint_region = "us-east-1"
+
+  enable_cloudformation_endpoint             = true
+  cloudformation_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_codepipeline_endpoint             = true
+  codepipeline_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_appmesh_envoy_management_endpoint             = true
+  appmesh_envoy_management_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_servicecatalog_endpoint             = true
+  servicecatalog_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_storagegateway_endpoint             = true
+  storagegateway_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sagemaker_api_endpoint             = true
+  sagemaker_api_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sagemaker_runtime_endpoint             = true
+  sagemaker_runtime_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_athena_endpoint             = true
+  athena_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_efs_endpoint             = true
+  efs_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_cloud_directory_endpoint             = true
+  cloud_directory_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_ebs_endpoint             = true
+  ebs_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_datasync_endpoint             = true
+  datasync_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_sms_endpoint             = true
+  sms_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_emr_endpoint             = true
+  emr_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_qldb_session_endpoint             = true
+  qldb_session_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_elasticbeanstalk_endpoint             = true
+  elasticbeanstalk_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_states_endpoint             = true
+  states_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
+  enable_acm_pca_endpoint             = true
+  acm_pca_endpoint_security_group_ids = [aws_security_group.vpc_interface_endpoints.id]
+
   tags = {
     "Bob" = "Alice"
   }
+}
+
+resource "aws_security_group" "vpc_interface_endpoints" {
+  name        = "example_security_group"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = module.vpc.vpc_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,12 +12,12 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 variable "vpc_name" {
-  description = "The name of the VPC"
+  description = "(Required) The name of the VPC"
   type        = string
 }
 
 variable "cidr_block" {
-  description = "The CIDR block for the VPC. The permissible size of the block ranges between a /16 netmask and a /28 netmask. We advice you to use a CIDR block reserved for private address space as recommended in RFC 1918 http://www.faqs.org/rfcs/rfc1918.html."
+  description = "(Required) The CIDR block for the VPC. The permissible size of the block ranges between a /16 netmask and a /28 netmask. We advice you to use a CIDR block reserved for private address space as recommended in RFC 1918 http://www.faqs.org/rfcs/rfc1918.html."
   type        = string
 
   # VPCs can vary in size from 16 addresses (/28 netmask) to 65536 addresses (/16 netmask).
@@ -37,55 +37,55 @@ variable "cidr_block" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 variable "assign_generated_ipv6_cidr_block" {
-  description = "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block."
+  description = "(Optional) Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IP addresses, or the size of the CIDR block."
   type        = bool
   default     = false
 }
 
 variable "allow_private_subnets_internet_access" {
-  description = "Whether or not to grant resoures inside the private subnets access to the public internet via NAT Gateways."
+  description = "(Optional) Whether or not to grant resoures inside the private subnets access to the public internet via NAT Gateways."
   type        = bool
   default     = true
 }
 
 variable "allow_intra_subnets_internet_access" {
-  description = "Whether or not to grant resoures inside the intra subnets access to the public internet via NAT Gateways."
+  description = "(Optional) Whether or not to grant resoures inside the intra subnets access to the public internet via NAT Gateways."
   type        = bool
   default     = false
 }
 
 variable "create" {
-  description = "Whether or not to create the VPC its associated resources."
+  description = "(Optional) Whether or not to create the VPC its associated resources."
   type        = bool
   default     = true
 }
 
 variable "enable_classiclink" {
-  description = "Whether or not to enable ClassicLink for the VPC. Only valid in regions and accounts that support EC2 Classic. Read more: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html"
+  description = "(Optional) Whether or not to enable ClassicLink for the VPC. Only valid in regions and accounts that support EC2 Classic. Read more: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html"
   type        = bool
   default     = false
 }
 
 variable "enable_classiclink_dns_support" {
-  description = "Whether or not to enable ClassicLink DNS Support for the VPC. Only valid in regions and accounts that support EC2 Classic."
+  description = "(Optional) Whether or not to enable ClassicLink DNS Support for the VPC. Only valid in regions and accounts that support EC2 Classic."
   type        = bool
   default     = false
 }
 
 variable "enable_dns_support" {
-  description = "Whether or not to enable DNS support in the VPC."
+  description = "(Optional) Whether or not to enable DNS support in the VPC."
   type        = bool
   default     = true
 }
 
 variable "enable_dns_hostnames" {
-  description = "Whether or not to enable DNS hostnames in the VPC."
+  description = "(Optional) Whether or not to enable DNS hostnames in the VPC."
   type        = bool
   default     = false
 }
 
 variable "create_nat_gateways" {
-  description = "Set the mode for the NAT Gateways. Possible inputs are \"none\" ( create not NAT Gateways at all ), \"single\" ( create a single Nat Gateway inside the first defined Public Subnet) and \"one_per_az\" ( Create one Nat Gatway inside the first Public Subnet in each availability zone )."
+  description = "(Optional) Set the mode for the NAT Gateways. Possible inputs are \"none\" ( create not NAT Gateways at all ), \"single\" ( create a single Nat Gateway inside the first defined Public Subnet) and \"one_per_az\" ( Create one Nat Gatway inside the first Public Subnet in each availability zone )."
   type        = string
 
   # Example:
@@ -96,13 +96,13 @@ variable "create_nat_gateways" {
 }
 
 variable "instance_tenancy" {
-  description = "A tenancy option for instances launched into the VPC."
+  description = "(Optional) A tenancy option for instances launched into the VPC."
   type        = string
   default     = "dedicated"
 }
 
 variable "public_subnets" {
-  description = "A map of public subnets to create for this VPC."
+  description = "(Optional) A map of public subnets to create for this VPC."
   type        = list(map(string))
 
   # Example:
@@ -125,7 +125,7 @@ variable "public_subnets" {
 }
 
 variable "private_subnets" {
-  description = "A map of private subnets to create for this VPC."
+  description = "(Optional) A map of private subnets to create for this VPC."
   type        = list(map(string))
 
   # Example:
@@ -148,7 +148,7 @@ variable "private_subnets" {
 }
 
 variable "intra_subnets" {
-  description = "A map of private intra subnets to create for this VPC."
+  description = "(Optional) A map of private intra subnets to create for this VPC."
   type        = list(map(string))
 
   # Example:
@@ -167,7 +167,7 @@ variable "intra_subnets" {
 }
 
 variable "tags" {
-  description = "A map of tags to apply to all created resources that support tags."
+  description = "(Optional) A map of tags to apply to all created resources that support tags."
   type        = map(string)
 
   # Example:
@@ -180,20 +180,7 @@ variable "tags" {
 }
 
 variable "eip_tags" {
-  description = "A map of tags to apply to the created NAT Gateway Elastic IP Addresses."
-  type        = map(string)
-
-  # Example:
-  #
-  # tags = {
-  #   CreatedAt = "2020-02-07",
-  #   Alice     = "Bob
-  # }
-  default = {}
-}
-
-variable "endpoint_tags" {
-  description = "A map of tags to apply to the created VPC endpoints."
+  description = "(Optional) A map of tags to apply to the created NAT Gateway Elastic IP Addresses."
   type        = map(string)
 
   # Example:
@@ -206,7 +193,7 @@ variable "endpoint_tags" {
 }
 
 variable "internet_gateway_tags" {
-  description = "A map of tags to apply to the created Internet Gateway."
+  description = "(Optional) A map of tags to apply to the created Internet Gateway."
   type        = map(string)
 
   # Example:
@@ -219,7 +206,7 @@ variable "internet_gateway_tags" {
 }
 
 variable "public_subnet_tags" {
-  description = "A map of tags to apply to the created public subnets."
+  description = "(Optional) A map of tags to apply to the created public subnets."
   type        = map(string)
 
   # Example:
@@ -232,7 +219,7 @@ variable "public_subnet_tags" {
 }
 
 variable "private_subnet_tags" {
-  description = "A map of tags to apply to the created Private Subnets."
+  description = "(Optional) A map of tags to apply to the created Private Subnets."
   type        = map(string)
 
   # Example:
@@ -245,7 +232,7 @@ variable "private_subnet_tags" {
 }
 
 variable "intra_subnet_tags" {
-  description = "A map of tags to apply to the created Intra Subnets."
+  description = "(Optional) A map of tags to apply to the created Intra Subnets."
   type        = map(string)
 
   # Example:
@@ -258,7 +245,7 @@ variable "intra_subnet_tags" {
 }
 
 variable "public_route_table_tags" {
-  description = "A map of tags to apply to the created Public Route Table."
+  description = "(Optional) A map of tags to apply to the created Public Route Table."
   type        = map(string)
 
   # Example:
@@ -271,7 +258,7 @@ variable "public_route_table_tags" {
 }
 
 variable "private_route_table_tags" {
-  description = "A map of tags to apply to the created Private Route Table."
+  description = "(Optional) A map of tags to apply to the created Private Route Table."
   type        = map(string)
 
   # Example:
@@ -284,7 +271,7 @@ variable "private_route_table_tags" {
 }
 
 variable "intra_route_table_tags" {
-  description = "A map of tags to apply to the created Intra Route Table."
+  description = "(Optional) A map of tags to apply to the created Intra Route Table."
   type        = map(string)
 
   # Example:
@@ -297,7 +284,7 @@ variable "intra_route_table_tags" {
 }
 
 variable "nat_gateway_tags" {
-  description = "A map of tags to apply to the created NAT Gateways."
+  description = "(Optional) A map of tags to apply to the created NAT Gateways."
   type        = map(string)
 
   # Example:
@@ -310,7 +297,2606 @@ variable "nat_gateway_tags" {
 }
 
 variable "vpc_tags" {
-  description = "A map of tags to apply to the created VPC."
+  description = "(Optional) A map of tags to apply to the created VPC."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# VPC Gateway Endpoints
+
+variable "endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the created VPC endpoints."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+variable "enable_dynamodb_endpoint" {
+  description = "(Optional) Should be true if you want to provision a DynamoDB endpoint to the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_s3_endpoint" {
+  description = "(Optional) Should be true if you want to provision an S3 endpoint to the VPC"
+  type        = bool
+  default     = true
+}
+
+# VPC Interface Endpoints
+
+variable "all_interface_endpoints_subnet_ids" {
+  description = "(Optional) A list of IDs of the subnets for all endpoints. Each endpoint will create one ENI (Elastic Network Interface) per subnet."
+  type        = list(string)
+  default     = []
+}
+
+variable "all_interface_endpoints_security_group_ids" {
+  # This allows you to control which resources can talk to this endpoint. You need to open port 443 for AWS API calls,
+  # since they run over HTTPS.
+  description = "(Optional) A list of IDs of the security groups which will apply for all endpoints."
+  type        = list(string)
+  default     = []
+}
+
+# Codebuild
+
+variable "enable_codebuild_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Codebuild endpoint to the VPC"
+  default     = false
+}
+
+variable "codebuild_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Codebuild endpoint"
+  default     = []
+}
+
+variable "codebuild_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Codebuilt endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "codebuild_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Codebuild endpoint"
+  default     = false
+}
+
+variable "codebuild_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "codebuild_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# Codecommit
+
+variable "enable_codecommit_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Codecommit endpoint to the VPC"
+  default     = false
+}
+
+variable "codecommit_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Codecommit endpoint"
+  default     = []
+}
+
+variable "codecommit_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Codecommit endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "codecommit_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Codecommit endpoint"
+  default     = false
+}
+
+variable "codecommit_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "codecommit_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# Git Codecommit
+
+variable "enable_git_codecommit_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Git Codecommit endpoint to the VPC"
+  default     = false
+}
+
+variable "git_codecommit_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Git Codecommit endpoint"
+  default     = []
+}
+
+variable "git_codecommit_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Git Codecommit endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "git_codecommit_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "git_codecommit_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Git Codecommit endpoint"
+  default     = false
+}
+
+variable "git_codecommit_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# Config
+
+variable "enable_config_endpoint" {
+  description = "(Optional) Should be true if you want to provision an config endpoint to the VPC"
+  default     = false
+}
+
+variable "config_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for config endpoint"
+  default     = []
+}
+
+variable "config_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "config_endpoint_subnet_ids" {
+
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for config endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "config_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for config endpoint"
+  default     = false
+}
+
+variable "config_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SQS
+
+variable "enable_sqs_endpoint" {
+  description = "(Optional) Should be true if you want to provision an SQS endpoint to the VPC"
+  default     = false
+}
+
+variable "sqs_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SQS endpoint"
+  default     = []
+}
+
+variable "sqs_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sqs_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SQS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+variable "sqs_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SQS endpoint"
+  default     = false
+}
+
+variable "sqs_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# Secrets Manager
+
+variable "enable_secretsmanager_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Secrets Manager endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "secretsmanager_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Secrets Manager endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "secretsmanager_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "secretsmanager_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Secrets Manager endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "secretsmanager_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Secrets Manager endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "secretsmanager_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SSM
+
+variable "enable_ssm_endpoint" {
+  description = "(Optional) Should be true if you want to provision an SSM endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ssm_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SSM endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ssm_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ssm_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SSM endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ssm_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SSM endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ssm_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SSM MESSAGES
+
+variable "enable_ssmmessages_endpoint" {
+  description = "(Optional) Should be true if you want to provision a SSMMESSAGES endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ssmmessages_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SSMMESSAGES endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ssmmessages_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ssmmessages_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SSMMESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ssmmessages_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SSMMESSAGES endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ssmmessages_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EC2
+
+variable "enable_ec2_endpoint" {
+  description = "(Optional) Should be true if you want to provision an EC2 endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ec2_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for EC2 endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ec2_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for EC2 endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ec2_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ec2_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for EC2 endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ec2_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EC2 MESSAGES
+
+variable "enable_ec2messages_endpoint" {
+  description = "(Optional) Should be true if you want to provision an EC2MESSAGES endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ec2messages_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for EC2MESSAGES endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ec2messages_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for EC2MESSAGES endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ec2messages_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ec2messages_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for EC2MESSAGES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ec2messages_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EC2 AUTOSCALING PLANS
+
+variable "enable_autoscaling_plans_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Auto Scaling Plans endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "autoscaling_plans_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Auto Scaling Plans endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "autoscaling_plans_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "autoscaling_plans_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Auto Scaling Plans endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "autoscaling_plans_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Auto Scaling Plans endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "autoscaling_plans_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EC2 AUTOSCALING
+
+variable "enable_ec2_autoscaling_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Auto Scaling Plans endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ec2_autoscaling_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Auto Scaling Plans endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ec2_autoscaling_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ec2_autoscaling_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Auto Scaling Plans endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ec2_autoscaling_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Auto Scaling Plans endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ec2_autoscaling_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+
+
+# TRANSFERSERVER
+
+variable "enable_transferserver_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Transfer Server endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "transferserver_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Transfer Server endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "transferserver_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Transfer Server endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "transferserver_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "transferserver_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Transfer Server endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "transferserver_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ECR API
+
+variable "enable_ecr_api_endpoint" {
+  description = "(Optional) Should be true if you want to provision an ecr api endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ecr_api_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for ECR api endpoint. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecr_api_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for ECR API endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ecr_api_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ecr_api_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for ECR API endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ecr_api_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ECR DKR
+
+variable "enable_ecr_dkr_endpoint" {
+  description = "(Optional) Should be true if you want to provision an ecr dkr endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ecr_dkr_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for ECR dkr endpoint. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecr_dkr_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for ECR DKR endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ecr_dkr_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ecr_dkr_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for ECR DKR endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ecr_dkr_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# API GATEWAY
+
+variable "enable_apigw_endpoint" {
+  description = "(Optional) Should be true if you want to provision an api gateway endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "apigw_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for API GW  endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "apigw_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for API GW endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "apigw_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "apigw_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for API GW endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "apigw_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# KMS
+
+variable "enable_kms_endpoint" {
+  description = "(Optional) Should be true if you want to provision a KMS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "kms_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for KMS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for KMS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kms_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for KMS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "kms_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ECS
+
+variable "enable_ecs_endpoint" {
+  description = "(Optional) Should be true if you want to provision a ECS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ecs_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for ECS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for ECS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ecs_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for ECS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ecs_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ECS AGENT
+
+variable "enable_ecs_agent_endpoint" {
+  description = "(Optional) Should be true if you want to provision a ECS Agent endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ecs_agent_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for ECS Agent endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_agent_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for ECS Agent endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_agent_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ecs_agent_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for ECS Agent endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ecs_agent_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+
+# ECS TELEMETRY
+
+variable "enable_ecs_telemetry_endpoint" {
+  description = "(Optional) Should be true if you want to provision a ECS Telemetry endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ecs_telemetry_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for ECS Telemetry endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_telemetry_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for ECS Telemetry endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+
+variable "ecs_telemetry_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ecs_telemetry_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for ECS Telemetry endpoint"
+  type        = bool
+  default     = false
+}
+variable "ecs_telemetry_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SNS
+
+variable "enable_sns_endpoint" {
+  description = "(Optional) Should be true if you want to provision a SNS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "sns_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SNS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "sns_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SNS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "sns_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sns_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SNS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "sns_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CLOUDWATCH MONITORING
+
+variable "enable_monitoring_endpoint" {
+  description = "(Optional) Should be true if you want to provision a CloudWatch Monitoring endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "monitoring_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for CloudWatch Monitoring endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "monitoring_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for CloudWatch Monitoring endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "monitoring_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "monitoring_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Monitoring endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "monitoring_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CLOUDWATCH LOGS
+
+variable "enable_logs_endpoint" {
+  description = "(Optional) Should be true if you want to provision a CloudWatch Logs endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "logs_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for CloudWatch Logs endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "logs_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for CloudWatch Logs endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "logs_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "logs_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Logs endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "logs_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CLOUDWATCH EVENTS
+
+variable "enable_events_endpoint" {
+  description = "(Optional) Should be true if you want to provision a CloudWatch Events endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "events_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for CloudWatch Events endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "events_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for CloudWatch Events endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "events_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "events_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for CloudWatch Events endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "events_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ELASTIC LOADBALANCING
+
+variable "enable_elasticloadbalancing_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Elastic Load Balancing endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "elasticloadbalancing_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Elastic Load Balancing endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "elasticloadbalancing_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Elastic Load Balancing endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "elasticloadbalancing_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "elasticloadbalancing_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Elastic Load Balancing endpoint"
+  type        = bool
+  default     = false
+}
+variable "elasticloadbalancing_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CLOUDTRAIL
+
+variable "enable_cloudtrail_endpoint" {
+  description = "(Optional) Should be true if you want to provision a CloudTrail endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "cloudtrail_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for CloudTrail endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudtrail_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for CloudTrail endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudtrail_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "cloudtrail_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for CloudTrail endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "cloudtrail_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# KINESIS STREAMS
+
+variable "enable_kinesis_streams_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Kinesis Streams endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "kinesis_streams_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Kinesis Streams endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "kinesis_streams_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Kinesis Streams endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "kinesis_streams_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kinesis_streams_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Kinesis Streams endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "kinesis_streams_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# KINESIS FIREHOSE
+
+variable "enable_kinesis_firehose_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Kinesis Firehose endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "kinesis_firehose_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Kinesis Firehose endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "kinesis_firehose_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Kinesis Firehose endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "kinesis_firehose_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "kinesis_firehose_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Kinesis Firehose endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "kinesis_firehose_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# GLUE
+
+variable "enable_glue_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Glue endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "glue_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Glue endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "glue_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Glue endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "glue_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "glue_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Glue endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "glue_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SAGEMAKER NOTEBOOK
+
+variable "enable_sagemaker_notebook_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Sagemaker Notebook endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "sagemaker_notebook_endpoint_region" {
+  description = "Region to use for Sagemaker Notebook endpoint"
+  type        = string
+  default     = null
+}
+
+variable "sagemaker_notebook_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Sagemaker Notebook endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "sagemaker_notebook_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Sagemaker Notebook endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+
+variable "sagemaker_notebook_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sagemaker_notebook_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Sagemaker Notebook endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "sagemaker_notebook_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# STS
+
+variable "enable_sts_endpoint" {
+  description = "(Optional) Should be true if you want to provision a STS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "sts_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for STS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "sts_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for STS endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "sts_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sts_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for STS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "sts_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CLOUDFORMATION
+
+variable "enable_cloudformation_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Cloudformation endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "cloudformation_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Cloudformation endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudformation_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Cloudformation endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudformation_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "cloudformation_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Cloudformation endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "cloudformation_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CODEPIPELINE
+
+variable "enable_codepipeline_endpoint" {
+  description = "(Optional) Should be true if you want to provision a CodePipeline endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "codepipeline_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for CodePipeline endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "codepipeline_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for CodePipeline endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "codepipeline_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "codepipeline_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for CodePipeline endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "codepipeline_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# APPMESH ENVOY
+
+variable "enable_appmesh_envoy_management_endpoint" {
+  description = "(Optional) Should be true if you want to provision a AppMesh endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "appmesh_envoy_management_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for AppMesh endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "appmesh_envoy_management_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for AppMesh endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "appmesh_envoy_management_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "appmesh_envoy_management_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for AppMesh endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "appmesh_envoy_management_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SERVICE CATALOG
+
+variable "enable_servicecatalog_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Service Catalog endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "servicecatalog_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Service Catalog endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "servicecatalog_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Service Catalog endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "servicecatalog_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "servicecatalog_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Service Catalog endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "servicecatalog_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# STORAGE GATEWAY
+
+variable "enable_storagegateway_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Storage Gateway endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "storagegateway_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Storage Gateway endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "storagegateway_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Storage Gateway endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "storagegatewat_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "storagegateway_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Storage Gateway endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "storagegateway_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# TRANSFER SERVICE
+
+variable "enable_transfer_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Transfer endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "transfer_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Transfer endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "transfer_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Transfer endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "transfer_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "transfer_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Transfer endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "transfer_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SAGEMAKER API
+
+variable "enable_sagemaker_api_endpoint" {
+  description = "(Optional) Should be true if you want to provision a SageMaker API endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "sagemaker_api_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SageMaker API endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "sagemaker_api_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SageMaker API endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "sagemaker_api_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sagemaker_api_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SageMaker API endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "sagemaker_api_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SAGEMAKER RUNTIME
+
+variable "enable_sagemaker_runtime_endpoint" {
+  description = "(Optional) Should be true if you want to provision a SageMaker Runtime endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "sagemaker_runtime_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SageMaker Runtime endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "sagemaker_runtime_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SageMaker Runtime endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "sagemaker_runtime_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sagemaker_runtime_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SageMaker Runtime endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "sagemaker_runtime_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# APPSTREAM
+
+variable "enable_appstream_endpoint" {
+  description = "(Optional) Should be true if you want to provision a AppStream endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "appstream_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for AppStream endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "appstream_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for AppStream endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "appstream_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "appstream_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for AppStream endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "appstream_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ATHENA
+
+variable "enable_athena_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Athena endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "athena_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Athena endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "athena_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Athena endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "athena_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "athena_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Athena endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "athena_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# REKOGNITION
+
+variable "enable_rekognition_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Rekognition endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "rekognition_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Rekognition endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "rekognition_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Rekognition endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+
+variable "rekognition_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "rekognition_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Rekognition endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "rekognition_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EFS
+
+variable "enable_efs_endpoint" {
+  description = "(Optional) Should be true if you want to provision an EFS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "efs_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for EFS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "efs_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for EFS endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "efs_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "efs_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for EFS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "efs_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# CLOUD DIRECTORY
+
+variable "enable_cloud_directory_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Cloud Directory endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "cloud_directory_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Cloud Directory endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloud_directory_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Cloud Directory endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "cloud_directory_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "cloud_directory_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Cloud Directory endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "cloud_directory_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SES
+
+variable "enable_ses_endpoint" {
+  description = "(Optional) Should be true if you want to provision an SES endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ses_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SES endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ses_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SES endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ses_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ses_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SES endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ses_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# WORKSPACES
+
+variable "enable_workspaces_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Workspaces endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "workspaces_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Workspaces endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "workspaces_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Workspaces endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+
+variable "workspaces_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "workspaces_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Workspaces endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "workspaces_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ACCESS ANALYZER
+
+variable "enable_access_analyzer_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Access Analyzer endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "access_analyzer_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Access Analyzer endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "access_analyzer_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Access Analyzer endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "access_analyzer_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "access_analyzer_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Access Analyzer endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "access_analyzer_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EBS
+
+variable "enable_ebs_endpoint" {
+  description = "(Optional) Should be true if you want to provision an EBS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "ebs_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for EBS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "ebs_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for EBS endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "ebs_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "ebs_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for EBS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "ebs_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# DATASYNC
+
+variable "enable_datasync_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Data Sync endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "datasync_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Data Sync endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "datasync_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Data Sync endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "datasync_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "datasync_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Data Sync endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "datasync_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ELASTIC INFERENCE RUNTIME
+
+variable "enable_elastic_inference_runtime_endpoint" {
+  description = "(Optional) Should be true if you want to provision an Elastic Inference Runtime endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "elastic_inference_runtime_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Elastic Inference Runtime endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "elastic_inference_runtime_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Elastic Inference Runtime endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "elastic_inference_runtime_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "elastic_inference_runtime_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Elastic Inference Runtime endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "elastic_inference_runtime_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# SMS
+
+variable "enable_sms_endpoint" {
+  description = "(Optional) Should be true if you want to provision an SMS endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "sms_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for SMS endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "sms_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for SMS endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "sms_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "sms_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for SMS endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "sms_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# EMR
+
+variable "enable_emr_endpoint" {
+  description = "(Optional) Should be true if you want to provision an EMR endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "emr_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for EMR endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "emr_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for EMR endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+
+variable "emr_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "emr_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for EMR endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "emr_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# QLDB
+
+variable "enable_qldb_session_endpoint" {
+  description = "(Optional) Should be true if you want to provision an QLDB Session endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "qldb_session_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for QLDB Session endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "qldb_session_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for QLDB Session endpoint. Only a single subnet within an AZ is supported. Ifomitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+
+variable "qldb_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "qldb_session_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for QLDB Session endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "qldb_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ELASTIC BEANSTALK
+
+variable "enable_elasticbeanstalk_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Elastic Beanstalk endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "elasticbeanstalk_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Elastic Beanstalk endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "elasticbeanstalk_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Elastic Beanstalk endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "elasticbeanstalk_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "elasticbeanstalk_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Elastic Beanstalk endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "elasticbeanstalk_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ELASTIC BEANSTALK HEALH
+
+variable "enable_elasticbeanstalk_health_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Elastic Beanstalk Health endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "elasticbeanstalk_health_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Elastic Beanstalk Health endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "elasticbeanstalk_health_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Elastic Beanstalk Health endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "elasticbeanstalk_health_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "elasticbeanstalk_health_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Elastic Beanstalk Health endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "elasticbeanstalk_health_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# STATES
+
+variable "enable_states_endpoint" {
+  description = "(Optional) Should be true if you want to provision a Step Function endpoint to the VPC"
+  type        = bool
+  default     = false
+}
+
+variable "states_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for Step Function endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "states_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Step Function endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  type        = list(string)
+  default     = []
+}
+
+variable "states_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "states_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for Step Function endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "states_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
+  type        = map(string)
+
+  # Example:
+  #
+  # tags = {
+  #   CreatedAt = "2020-02-07",
+  #   Alice     = "Bob
+  # }
+  default = {}
+}
+
+# ACM
+
+variable "enable_acm_pca_endpoint" {
+  description = "(Optional) Should be true if you want to provision an ACM PCA endpoint to the VPC"
+  default     = false
+}
+
+variable "acm_pca_endpoint_security_group_ids" {
+  description = "(Optional) The ID of one or more security groups to associate with the network interface for ACM PCA endpoint"
+  default     = []
+}
+
+variable "acm_pca_endpoint_subnet_ids" {
+  description = "(Optional) The ID of one or more subnets in which to create a network interface for Codebuilt endpoint. Only a single subnet within an AZ is supported. If omitted, private subnets will be used."
+  default     = []
+}
+
+
+variable "acm_pca_endpoint_policy" {
+  description = "(Optional) IAM policy to restrict what resources can call this endpoint. For example, you can add an IAM policy that allows EC2 instances to talk to this endpoint but no other types of resources. If not specified, all resources will be allowed to call this endpoint."
+  type        = string
+  default     = null
+}
+
+variable "acm_pca_endpoint_private_dns_enabled" {
+  description = "(Optional) Whether or not to associate a private hosted zone with the specified VPC for ACM PCA endpoint"
+  default     = false
+}
+
+variable "acm_pca_endpoint_tags" {
+  description = "(Optional) A map of tags to apply to the codebuild interface endpoint."
   type        = map(string)
 
   # Example:

--- a/vpc-gateway-endpoints.tf
+++ b/vpc-gateway-endpoints.tf
@@ -1,0 +1,86 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC GATEWAY ENDPOINTS
+#
+# A VPC endpoint enables you to privately connect your VPC to supported AWS services and VPC endpoint services powered
+# by AWS PrivateLink without requiring an internet gateway, NAT device, VPN connection,
+# or AWS Direct Connect connection. Instances in your VPC do not require public IP addresses to communicate with
+# resources in the service. Traffic between your VPC and the other service does not leave the Amazon network.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Gateway Endpoint for S3
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "s3" {
+  count = var.create && var.enable_s3_endpoint ? 1 : 0
+
+  service = "s3"
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  count = var.create && var.enable_s3_endpoint ? 1 : 0
+
+  vpc_id       = aws_vpc.vpc[0].id
+  service_name = data.aws_vpc_endpoint_service.s3[0].service_name
+  tags         = var.tags
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3_public" {
+  count = var.create && var.enable_s3_endpoint && length(aws_subnet.public) > 0 ? 1 : 0
+
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = aws_route_table.public[0].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3_private" {
+  for_each = var.create && var.enable_s3_endpoint ? aws_subnet.private : {}
+
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = aws_route_table.private[each.key].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "s3_intra" {
+  for_each = var.create && var.enable_s3_endpoint ? aws_subnet.intra : {}
+
+  vpc_endpoint_id = aws_vpc_endpoint.s3[0].id
+  route_table_id  = aws_route_table.intra[each.key].id
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Gateway Endpoint for DynamoDB
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "dynamodb" {
+  count = var.create && var.enable_dynamodb_endpoint ? 1 : 0
+
+  service = "dynamodb"
+}
+resource "aws_vpc_endpoint" "dynamodb" {
+  count = var.create && var.enable_dynamodb_endpoint ? 1 : 0
+
+  vpc_id       = aws_vpc.vpc[0].id
+  service_name = data.aws_vpc_endpoint_service.dynamodb[0].service_name
+  tags         = var.tags
+}
+
+resource "aws_vpc_endpoint_route_table_association" "dynamodb_public" {
+  count = var.create && var.enable_dynamodb_endpoint && length(var.public_subnets) > 0 ? 1 : 0
+
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+  route_table_id  = aws_route_table.public[0].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "dynamodb_private" {
+  for_each = var.create && var.enable_dynamodb_endpoint ? aws_subnet.private : {}
+
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+  route_table_id  = aws_route_table.private[each.key].id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "dynamodb_intra" {
+  for_each = var.create && var.enable_dynamodb_endpoint ? aws_subnet.intra : {}
+
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb[0].id
+  route_table_id  = aws_route_table.intra[each.key].id
+
+}

--- a/vpc-interface-endpoints.tf
+++ b/vpc-interface-endpoints.tf
@@ -1,0 +1,1347 @@
+locals {
+  private_subnet_ids = [for subnet in aws_subnet.private : subnet.id]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Codebuild
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "codebuild" {
+  count = var.create && var.enable_codebuild_endpoint ? 1 : 0
+
+  service = "codebuild"
+}
+
+resource "aws_vpc_endpoint" "codebuild" {
+  count = var.create && var.enable_codebuild_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.codebuild[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.codebuild_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.codebuild_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.codebuild_endpoint_private_dns_enabled
+  policy              = var.codebuild_endpoint_policy
+  tags                = merge(var.codebuild_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Code Commit
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "codecommit" {
+  count = var.create && var.enable_codecommit_endpoint ? 1 : 0
+
+  service = "codecommit"
+}
+
+resource "aws_vpc_endpoint" "codecommit" {
+  count = var.create && var.enable_codecommit_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.codecommit[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.codecommit_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.codecommit_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.codecommit_endpoint_private_dns_enabled
+  policy              = var.codecommit_endpoint_policy
+  tags                = merge(var.codecommit_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Git Code Commit
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "git_codecommit" {
+  count = var.create && var.enable_git_codecommit_endpoint ? 1 : 0
+
+  service = "git-codecommit"
+}
+
+resource "aws_vpc_endpoint" "git_codecommit" {
+  count = var.create && var.enable_git_codecommit_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.git_codecommit[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.git_codecommit_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.git_codecommit_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.git_codecommit_endpoint_private_dns_enabled
+  policy              = var.git_codecommit_endpoint_policy
+  tags                = merge(var.git_codecommit_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Config
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "config" {
+  count = var.create && var.enable_config_endpoint ? 1 : 0
+
+  service = "config"
+}
+
+resource "aws_vpc_endpoint" "config" {
+  count = var.create && var.enable_config_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.config[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.config_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.config_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.config_endpoint_private_dns_enabled
+  policy              = var.config_endpoint_policy
+  tags                = merge(var.config_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SQS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sqs" {
+  count = var.create && var.enable_sqs_endpoint ? 1 : 0
+
+  service = "sqs"
+}
+
+resource "aws_vpc_endpoint" "sqs" {
+  count = var.create && var.enable_sqs_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sqs[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sqs_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sqs_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sqs_endpoint_private_dns_enabled
+  policy              = var.sqs_endpoint_policy
+  tags                = merge(var.sqs_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Secrets Manager
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "secretsmanager" {
+  count = var.create && var.enable_secretsmanager_endpoint ? 1 : 0
+
+  service = "secretsmanager"
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  count = var.create && var.enable_secretsmanager_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.secretsmanager[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.secretsmanager_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.secretsmanager_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.secretsmanager_endpoint_private_dns_enabled
+  policy              = var.secretsmanager_endpoint_policy
+  tags                = merge(var.secretsmanager_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SSM
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ssm" {
+  count = var.create && var.enable_ssm_endpoint ? 1 : 0
+
+  service = "ssm"
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  count = var.create && var.enable_ssm_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ssm[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ssm_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ssm_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ssm_endpoint_private_dns_enabled
+  policy              = var.ssm_endpoint_policy
+  tags                = merge(var.ssm_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SSMMESSAGESC
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ssmmessages" {
+  count = var.create && var.enable_ssmmessages_endpoint ? 1 : 0
+
+  service = "ssmmessages"
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  count = var.create && var.enable_ssmmessages_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ssmmessages[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ssmmessages_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ssmmessages_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ssmmessages_endpoint_private_dns_enabled
+  policy              = var.ssmmessages_endpoint_policy
+  tags                = merge(var.ssmmessages_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for EC2
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ec2" {
+  count = var.create && var.enable_ec2_endpoint ? 1 : 0
+
+  service = "ec2"
+}
+
+resource "aws_vpc_endpoint" "ec2" {
+  count = var.create && var.enable_ec2_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ec2[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ec2_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ec2_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ec2_endpoint_private_dns_enabled
+  policy              = var.ec2_endpoint_policy
+  tags                = merge(var.ec2_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for EC2MESSAGES
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ec2messages" {
+  count = var.create && var.enable_ec2messages_endpoint ? 1 : 0
+
+  service = "ec2messages"
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  count = var.create && var.enable_ec2messages_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ec2messages[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ec2messages_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ec2messages_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ec2messages_endpoint_private_dns_enabled
+  policy              = var.ec2messages_endpoint_policy
+  tags                = merge(var.ec2messages_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Auto Scaling Plans
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "auto_scaling_plans" {
+  count = var.create && var.enable_autoscaling_plans_endpoint ? 1 : 0
+
+  service = "autoscaling-plans"
+}
+
+resource "aws_vpc_endpoint" "auto_scaling_plans" {
+  count = var.create && var.enable_autoscaling_plans_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.auto_scaling_plans[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = var.autoscaling_plans_endpoint_security_group_ids
+  subnet_ids          = coalescelist(var.autoscaling_plans_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.autoscaling_plans_endpoint_private_dns_enabled
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for EC2 Autoscaling
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ec2_autoscaling" {
+  count = var.create && var.enable_ec2_autoscaling_endpoint ? 1 : 0
+
+  service = "autoscaling"
+}
+
+resource "aws_vpc_endpoint" "ec2_autoscaling" {
+  count = var.create && var.enable_ec2_autoscaling_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ec2_autoscaling[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ec2_autoscaling_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ec2_autoscaling_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ec2_autoscaling_endpoint_private_dns_enabled
+  policy              = var.ec2_autoscaling_endpoint_policy
+  tags                = merge(var.ec2_autoscaling_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Transfer Server
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "transferserver" {
+  count = var.create && var.enable_transferserver_endpoint ? 1 : 0
+
+  service = "transfer.server"
+}
+
+resource "aws_vpc_endpoint" "transferserver" {
+  count = var.create && var.enable_transferserver_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.transferserver[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.transferserver_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.transferserver_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.transferserver_endpoint_private_dns_enabled
+  policy              = var.transferserver_endpoint_policy
+  tags                = merge(var.transferserver_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for ECR API
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ecr_api" {
+  count = var.create && var.enable_ecr_api_endpoint ? 1 : 0
+
+  service = "ecr.api"
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  count = var.create && var.enable_ecr_api_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ecr_api[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ecr_api_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ecr_api_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ecr_api_endpoint_private_dns_enabled
+  policy              = var.ecr_api_endpoint_policy
+  tags                = merge(var.ecr_api_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for ECR DKR
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ecr_dkr" {
+  count = var.create && var.enable_ecr_dkr_endpoint ? 1 : 0
+
+  service = "ecr.dkr"
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  count = var.create && var.enable_ecr_dkr_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ecr_dkr[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ecr_dkr_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ecr_dkr_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ecr_dkr_endpoint_private_dns_enabled
+  policy              = var.ecr_dkr_endpoint_policy
+  tags                = merge(var.ecr_dkr_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for API Gateway
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "apigw" {
+  count = var.create && var.enable_apigw_endpoint ? 1 : 0
+
+  service = "execute-api"
+}
+
+resource "aws_vpc_endpoint" "apigw" {
+  count = var.create && var.enable_apigw_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.apigw[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.apigw_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.apigw_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.apigw_endpoint_private_dns_enabled
+  policy              = var.apigw_endpoint_policy
+  tags                = merge(var.apigw_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for KMS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "kms" {
+  count = var.create && var.enable_kms_endpoint ? 1 : 0
+
+  service = "kms"
+}
+
+resource "aws_vpc_endpoint" "kms" {
+  count = var.create && var.enable_kms_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.kms[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.kms_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.kms_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.kms_endpoint_private_dns_enabled
+  policy              = var.kms_endpoint_policy
+  tags                = merge(var.kms_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for ECS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ecs" {
+  count = var.create && var.enable_ecs_endpoint ? 1 : 0
+
+  service = "ecs"
+}
+
+resource "aws_vpc_endpoint" "ecs" {
+  count = var.create && var.enable_ecs_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ecs[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ecs_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ecs_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ecs_endpoint_private_dns_enabled
+  policy              = var.ecs_endpoint_policy
+  tags                = merge(var.ecs_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for ECS Agent
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ecs_agent" {
+  count = var.create && var.enable_ecs_agent_endpoint ? 1 : 0
+
+  service = "ecs-agent"
+}
+
+resource "aws_vpc_endpoint" "ecs_agent" {
+  count = var.create && var.enable_ecs_agent_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ecs_agent[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ecs_agent_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ecs_agent_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ecs_agent_endpoint_private_dns_enabled
+  policy              = var.ecs_agent_endpoint_policy
+  tags                = merge(var.ecs_agent_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for ECS Telemetry
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ecs_telemetry" {
+  count = var.create && var.enable_ecs_telemetry_endpoint ? 1 : 0
+
+  service = "ecs-telemetry"
+}
+
+resource "aws_vpc_endpoint" "ecs_telemetry" {
+  count = var.create && var.enable_ecs_telemetry_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ecs_telemetry[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ecs_telemetry_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ecs_telemetry_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ecs_telemetry_endpoint_private_dns_enabled
+  policy              = var.ecs_telemetry_endpoint_policy
+  tags                = merge(var.ecs_telemetry_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SNS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sns" {
+  count = var.create && var.enable_sns_endpoint ? 1 : 0
+
+  service = "sns"
+}
+
+resource "aws_vpc_endpoint" "sns" {
+  count = var.create && var.enable_sns_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sns[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sns_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sns_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sns_endpoint_private_dns_enabled
+  policy              = var.sns_endpoint_policy
+  tags                = merge(var.sns_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for CloudWatch Monitoring
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "monitoring" {
+  count = var.create && var.enable_monitoring_endpoint ? 1 : 0
+
+  service = "monitoring"
+}
+
+resource "aws_vpc_endpoint" "monitoring" {
+  count = var.create && var.enable_monitoring_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.monitoring[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.monitoring_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.monitoring_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.monitoring_endpoint_private_dns_enabled
+  policy              = var.monitoring_endpoint_policy
+  tags                = merge(var.monitoring_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for CloudWatch Logs
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "logs" {
+  count = var.create && var.enable_logs_endpoint ? 1 : 0
+
+  service = "logs"
+}
+
+resource "aws_vpc_endpoint" "logs" {
+  count = var.create && var.enable_logs_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.logs[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.logs_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.logs_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.logs_endpoint_private_dns_enabled
+  policy              = var.logs_endpoint_policy
+  tags                = merge(var.logs_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for CloudWatch Events
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "events" {
+  count = var.create && var.enable_events_endpoint ? 1 : 0
+
+  service = "events"
+}
+
+resource "aws_vpc_endpoint" "events" {
+  count = var.create && var.enable_events_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.events[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.events_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.events_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.events_endpoint_private_dns_enabled
+  policy              = var.events_endpoint_policy
+  tags                = merge(var.events_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Elastic Load Balancing
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "elasticloadbalancing" {
+  count = var.create && var.enable_elasticloadbalancing_endpoint ? 1 : 0
+
+  service = "elasticloadbalancing"
+}
+
+resource "aws_vpc_endpoint" "elasticloadbalancing" {
+  count = var.create && var.enable_elasticloadbalancing_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.elasticloadbalancing[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.elasticloadbalancing_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.elasticloadbalancing_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.elasticloadbalancing_endpoint_private_dns_enabled
+  policy              = var.elasticloadbalancing_endpoint_policy
+  tags                = merge(var.elasticloadbalancing_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for CloudTrail
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "cloudtrail" {
+  count = var.create && var.enable_cloudtrail_endpoint ? 1 : 0
+
+  service = "cloudtrail"
+}
+
+resource "aws_vpc_endpoint" "cloudtrail" {
+  count = var.create && var.enable_cloudtrail_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.cloudtrail[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.cloudtrail_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.cloudtrail_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.cloudtrail_endpoint_private_dns_enabled
+  policy              = var.cloudtrail_endpoint_policy
+  tags                = merge(var.cloudtrail_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Kinesis Streams
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "kinesis_streams" {
+  count = var.create && var.enable_kinesis_streams_endpoint ? 1 : 0
+
+  service = "kinesis-streams"
+}
+
+resource "aws_vpc_endpoint" "kinesis_streams" {
+  count = var.create && var.enable_kinesis_streams_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.kinesis_streams[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.kinesis_streams_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.kinesis_streams_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.kinesis_streams_endpoint_private_dns_enabled
+  policy              = var.kinesis_streams_endpoint_policy
+  tags                = merge(var.kinesis_streams_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Kinesis Firehose
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "kinesis_firehose" {
+  count = var.create && var.enable_kinesis_firehose_endpoint ? 1 : 0
+
+  service = "kinesis-firehose"
+}
+
+resource "aws_vpc_endpoint" "kinesis_firehose" {
+  count = var.create && var.enable_kinesis_firehose_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.kinesis_firehose[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.kinesis_firehose_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.kinesis_firehose_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.kinesis_firehose_endpoint_private_dns_enabled
+  policy              = var.kinesis_firehose_endpoint_policy
+  tags                = merge(var.kinesis_firehose_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Glue
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "glue" {
+  count = var.create && var.enable_glue_endpoint ? 1 : 0
+
+  service = "glue"
+}
+
+resource "aws_vpc_endpoint" "glue" {
+  count = var.create && var.enable_glue_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.glue[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.glue_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.glue_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.glue_endpoint_private_dns_enabled
+  policy              = var.glue_endpoint_policy
+  tags                = merge(var.glue_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SageMaker API
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sagemaker_api" {
+  count = var.create && var.enable_sagemaker_api_endpoint ? 1 : 0
+
+  service = "sagemaker.api"
+}
+
+resource "aws_vpc_endpoint" "sagemaker_api" {
+  count = var.create && var.enable_sagemaker_api_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sagemaker_api[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sagemaker_api_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sagemaker_api_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sagemaker_api_endpoint_private_dns_enabled
+  policy              = var.sagemaker_api_endpoint_policy
+  tags                = merge(var.sagemaker_api_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Sagemaker Notebooks
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sagemaker_notebook" {
+  count = var.create && var.enable_sagemaker_notebook_endpoint ? 1 : 0
+
+  service_name = "aws.sagemaker.${var.sagemaker_notebook_endpoint_region}.notebook"
+}
+
+resource "aws_vpc_endpoint" "sagemaker_notebook" {
+  count = var.create && var.enable_sagemaker_notebook_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sagemaker_notebook[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sagemaker_notebook_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sagemaker_notebook_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sagemaker_notebook_endpoint_private_dns_enabled
+  policy              = var.sagemaker_notebook_endpoint_policy
+  tags                = merge(var.sagemaker_notebook_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SageMaker Runtime
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sagemaker_runtime" {
+  count = var.create && var.enable_sagemaker_runtime_endpoint ? 1 : 0
+
+  service = "sagemaker.runtime"
+}
+
+resource "aws_vpc_endpoint" "sagemaker_runtime" {
+  count = var.create && var.enable_sagemaker_runtime_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sagemaker_runtime[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sagemaker_runtime_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sagemaker_runtime_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sagemaker_runtime_endpoint_private_dns_enabled
+  policy              = var.sagemaker_runtime_endpoint_policy
+  tags                = merge(var.sagemaker_runtime_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for STS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sts" {
+  count = var.create && var.enable_sts_endpoint ? 1 : 0
+
+  service = "sts"
+}
+
+resource "aws_vpc_endpoint" "sts" {
+  count = var.create && var.enable_sts_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sts[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sts_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sts_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sts_endpoint_private_dns_enabled
+  policy              = var.sts_endpoint_policy
+  tags                = merge(var.sts_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Cloudformation
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "cloudformation" {
+  count = var.create && var.enable_cloudformation_endpoint ? 1 : 0
+
+  service = "cloudformation"
+}
+
+resource "aws_vpc_endpoint" "cloudformation" {
+  count = var.create && var.enable_cloudformation_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.cloudformation[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.cloudformation_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.cloudformation_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.cloudformation_endpoint_private_dns_enabled
+  policy              = var.cloudformation_endpoint_policy
+  tags                = merge(var.cloudformation_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for CodePipeline
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "codepipeline" {
+  count = var.create && var.enable_codepipeline_endpoint ? 1 : 0
+
+  service = "codepipeline"
+}
+
+resource "aws_vpc_endpoint" "codepipeline" {
+  count = var.create && var.enable_codepipeline_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.codepipeline[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.codepipeline_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.codepipeline_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.codepipeline_endpoint_private_dns_enabled
+  policy              = var.codepipeline_endpoint_policy
+  tags                = merge(var.codepipeline_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for AppMesh
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "appmesh_envoy_management" {
+  count = var.create && var.enable_appmesh_envoy_management_endpoint ? 1 : 0
+
+  service = "appmesh-envoy-management"
+}
+
+resource "aws_vpc_endpoint" "appmesh_envoy_management" {
+  count = var.create && var.enable_appmesh_envoy_management_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.appmesh_envoy_management[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.appmesh_envoy_management_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.appmesh_envoy_management_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.appmesh_envoy_management_endpoint_private_dns_enabled
+  policy              = var.appmesh_envoy_management_endpoint_policy
+  tags                = merge(var.appmesh_envoy_management_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Service Catalog
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "servicecatalog" {
+  count = var.create && var.enable_servicecatalog_endpoint ? 1 : 0
+
+  service = "servicecatalog"
+}
+
+resource "aws_vpc_endpoint" "servicecatalog" {
+  count = var.create && var.enable_servicecatalog_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.servicecatalog[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.servicecatalog_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.servicecatalog_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.servicecatalog_endpoint_private_dns_enabled
+  policy              = var.servicecatalog_endpoint_policy
+  tags                = merge(var.servicecatalog_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Storage Gateway
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "storagegateway" {
+  count = var.create && var.enable_storagegateway_endpoint ? 1 : 0
+
+  service = "storagegateway"
+}
+
+resource "aws_vpc_endpoint" "storagegateway" {
+  count = var.create && var.enable_storagegateway_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.storagegateway[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.storagegateway_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.storagegateway_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.storagegateway_endpoint_private_dns_enabled
+  policy              = var.storagegatewat_endpoint_policy
+  tags                = merge(var.storagegateway_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Transfer
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "transfer" {
+  count = var.create && var.enable_transfer_endpoint ? 1 : 0
+
+  service = "transfer"
+}
+
+resource "aws_vpc_endpoint" "transfer" {
+  count = var.create && var.enable_transfer_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.transfer[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.transfer_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.transfer_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.transfer_endpoint_private_dns_enabled
+  policy              = var.transfer_endpoint_policy
+  tags                = merge(var.transfer_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for AppStream
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "appstream" {
+  count = var.create && var.enable_appstream_endpoint ? 1 : 0
+
+  service = "appstream"
+}
+
+resource "aws_vpc_endpoint" "appstream" {
+  count = var.create && var.enable_appstream_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.appstream[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.appstream_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.appstream_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.appstream_endpoint_private_dns_enabled
+  policy              = var.appstream_endpoint_policy
+  tags                = merge(var.appstream_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Athena
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "athena" {
+  count = var.create && var.enable_athena_endpoint ? 1 : 0
+
+  service = "athena"
+}
+
+resource "aws_vpc_endpoint" "athena" {
+  count = var.create && var.enable_athena_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.athena[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.athena_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.athena_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.athena_endpoint_private_dns_enabled
+  policy              = var.athena_endpoint_policy
+  tags                = merge(var.athena_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Rekognition
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "rekognition" {
+  count = var.create && var.enable_rekognition_endpoint ? 1 : 0
+
+  service = "rekognition"
+}
+
+resource "aws_vpc_endpoint" "rekognition" {
+  count = var.create && var.enable_rekognition_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.rekognition[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.rekognition_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.rekognition_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.rekognition_endpoint_private_dns_enabled
+  policy              = var.rekognition_endpoint_policy
+  tags                = merge(var.rekognition_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for EFS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "efs" {
+  count = var.create && var.enable_efs_endpoint ? 1 : 0
+
+  service = "elasticfilesystem"
+}
+
+resource "aws_vpc_endpoint" "efs" {
+  count = var.create && var.enable_efs_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.efs[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.efs_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.efs_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.efs_endpoint_private_dns_enabled
+  policy              = var.efs_endpoint_policy
+  tags                = merge(var.efs_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Cloud Directory
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "cloud_directory" {
+  count = var.create && var.enable_cloud_directory_endpoint ? 1 : 0
+
+  service = "clouddirectory"
+}
+
+resource "aws_vpc_endpoint" "cloud_directory" {
+  count = var.create && var.enable_cloud_directory_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.cloud_directory[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.cloud_directory_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.cloud_directory_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.cloud_directory_endpoint_private_dns_enabled
+  policy              = var.cloud_directory_endpoint_policy
+  tags                = merge(var.cloud_directory_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Workspaces
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "workspaces" {
+  count = var.create && var.enable_workspaces_endpoint ? 1 : 0
+
+  service = "workspaces"
+}
+
+resource "aws_vpc_endpoint" "workspaces" {
+  count = var.create && var.enable_workspaces_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.workspaces[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.workspaces_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.workspaces_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.workspaces_endpoint_private_dns_enabled
+  policy              = var.workspaces_endpoint_policy
+  tags                = merge(var.workspaces_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Access Analyzer
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "access_analyzer" {
+  count = var.create && var.enable_access_analyzer_endpoint ? 1 : 0
+
+  service = "access-analyzer"
+}
+
+resource "aws_vpc_endpoint" "access_analyzer" {
+  count = var.create && var.enable_access_analyzer_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.access_analyzer[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.access_analyzer_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.access_analyzer_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.access_analyzer_endpoint_private_dns_enabled
+  policy              = var.access_analyzer_endpoint_policy
+  tags                = merge(var.access_analyzer_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for EBS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ebs" {
+  count = var.create && var.enable_ebs_endpoint ? 1 : 0
+
+  service = "ebs"
+}
+
+resource "aws_vpc_endpoint" "ebs" {
+  count = var.create && var.enable_ebs_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ebs[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ebs_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ebs_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ebs_endpoint_private_dns_enabled
+  policy              = var.ebs_endpoint_policy
+  tags                = merge(var.ebs_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Data Sync
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "datasync" {
+  count = var.create && var.enable_datasync_endpoint ? 1 : 0
+
+  service = "datasync"
+}
+
+resource "aws_vpc_endpoint" "datasync" {
+  count = var.create && var.enable_datasync_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.datasync[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.datasync_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.datasync_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.datasync_endpoint_private_dns_enabled
+  policy              = var.datasync_endpoint_policy
+  tags                = merge(var.datasync_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Elastic Inference Runtime
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "elastic_inference_runtime" {
+  count = var.create && var.enable_elastic_inference_runtime_endpoint ? 1 : 0
+
+  service = "elastic-inference.runtime"
+}
+
+resource "aws_vpc_endpoint" "elastic_inference_runtime" {
+  count = var.create && var.enable_elastic_inference_runtime_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.elastic_inference_runtime[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.elastic_inference_runtime_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.elastic_inference_runtime_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.elastic_inference_runtime_endpoint_private_dns_enabled
+  policy              = var.elastic_inference_runtime_endpoint_policy
+  tags                = merge(var.elastic_inference_runtime_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SMS
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "sms" {
+  count = var.create && var.enable_sms_endpoint ? 1 : 0
+
+  service = "sms"
+}
+
+resource "aws_vpc_endpoint" "sms" {
+  count = var.create && var.enable_sms_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.sms[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.sms_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.sms_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.sms_endpoint_private_dns_enabled
+  policy              = var.sms_endpoint_policy
+  tags                = merge(var.sms_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for EMR
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "emr" {
+  count = var.create && var.enable_emr_endpoint ? 1 : 0
+
+  service = "elasticmapreduce"
+}
+
+resource "aws_vpc_endpoint" "emr" {
+  count = var.create && var.enable_emr_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.emr[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.emr_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.emr_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.emr_endpoint_private_dns_enabled
+  policy              = var.emr_endpoint_policy
+  tags                = merge(var.emr_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for QLDB Session
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "states" {
+  count = var.create && var.enable_states_endpoint ? 1 : 0
+
+  service = "states"
+}
+
+resource "aws_vpc_endpoint" "states" {
+  count = var.create && var.enable_states_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.states[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.states_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.states_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.states_endpoint_private_dns_enabled
+  policy              = var.states_endpoint_policy
+  tags                = merge(var.states_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Elastic Beanstalk
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "elasticbeanstalk" {
+  count = var.create && var.enable_elasticbeanstalk_endpoint ? 1 : 0
+
+  service = "elasticbeanstalk"
+}
+
+resource "aws_vpc_endpoint" "elasticbeanstalk" {
+  count = var.create && var.enable_elasticbeanstalk_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.elasticbeanstalk[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.elasticbeanstalk_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.elasticbeanstalk_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.elasticbeanstalk_endpoint_private_dns_enabled
+  policy              = var.elasticbeanstalk_endpoint_policy
+  tags                = merge(var.elasticbeanstalk_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for Elastic Beanstalk Health
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "elasticbeanstalk_health" {
+  count = var.create && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
+
+  service = "elasticbeanstalk.health"
+}
+
+resource "aws_vpc_endpoint" "elasticbeanstalk_health" {
+  count = var.create && var.enable_elasticbeanstalk_health_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.elasticbeanstalk_health[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.elasticbeanstalk_health_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.elasticbeanstalk_health_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.elasticbeanstalk_health_endpoint_private_dns_enabled
+  policy              = var.elasticbeanstalk_health_endpoint_policy
+  tags                = merge(var.elasticbeanstalk_health_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for ACM PCA
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "acm_pca" {
+  count = var.create && var.enable_acm_pca_endpoint ? 1 : 0
+
+  service = "acm-pca"
+}
+
+resource "aws_vpc_endpoint" "acm_pca" {
+  count = var.create && var.enable_acm_pca_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.acm_pca[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.acm_pca_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.acm_pca_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.acm_pca_endpoint_private_dns_enabled
+  policy              = var.acm_pca_endpoint_policy
+  tags                = merge(var.acm_pca_endpoint_tags, var.tags)
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# VPC Endpoint for SES
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc_endpoint_service" "ses" {
+  count = var.create && var.enable_ses_endpoint ? 1 : 0
+
+  service = "email-smtp"
+}
+
+resource "aws_vpc_endpoint" "ses" {
+  count = var.create && var.enable_ses_endpoint ? 1 : 0
+
+  vpc_id            = aws_vpc.vpc[0].id
+  service_name      = data.aws_vpc_endpoint_service.ses[0].service_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids  = coalescelist(var.all_interface_endpoints_security_group_ids, var.ses_endpoint_security_group_ids)
+  subnet_ids          = coalescelist(var.all_interface_endpoints_subnet_ids, var.ses_endpoint_subnet_ids, local.private_subnet_ids)
+  private_dns_enabled = var.ses_endpoint_private_dns_enabled
+  policy              = var.ses_endpoint_policy
+  tags                = merge(var.ses_endpoint_tags, var.tags)
+}


### PR DESCRIPTION
This PR adds support for
- VPC Gateway Endpoints ( S3 & DynamoDB ) that are enabled by default.
- VPC Interface Endpoints ( to be enabled optionally )
- add `Optional` and `Required` flags to all variables

Fixes #2 

Documentation, examples, and further tests will follow in another PR.