### PR TITLE
feat: byo nat eips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0]
+
+### Added
+
+- Add `nat_gateway_single_mode_zone` to be able to set a fixed zone for single NAT gateway deployments.
+- Add `nat_gateway_eip_allocation_ids` to allow bringing external EIPs instead of creating them with the module.
+
 ## [0.6.0]
 
 ### Added
@@ -117,13 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document the usage of examples
 - Add unit tests for basic use cases
 
-<!-- markdown-link-check-disable -->
-
 [unreleased]: https://github.com/mineiros-io/terraform-aws-vpc/compare/v0.6.0...HEAD
+[0.7.0]: https://github.com/mineiros-io/terraform-aws-vpc/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mineiros-io/terraform-aws-vpc/compare/v0.5.0...v0.6.0
-
-<!-- markdown-link-check-enable -->
-
 [0.5.0]: https://github.com/mineiros-io/terraform-aws-vpc/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/mineiros-io/terraform-aws-vpc/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mineiros-io/terraform-aws-vpc/compare/v0.2.0...v0.3.0

--- a/Makefile
+++ b/Makefile
@@ -127,5 +127,5 @@ DOCKER_RUN_CMD  = docker run ${DOCKER_FLAGS} ${BUILD_TOOLS_DOCKER_IMAGE}
 
 quiet-command = $(if ${V},${1},$(if ${2},@echo ${2} && ${1}, @${1}))
 docker-run    = $(call quiet-command,${DOCKER_RUN_CMD} ${1} | cat,"${YELLOW}[DOCKER RUN] ${GREEN}${1}${RESET}")
-go-test       = $(call quiet-command,${DOCKER_RUN_CMD} go test -v -count 1 -timeout 45m -parallel 128 ${1} | cat,"${YELLOW}[TEST] ${GREEN}${1}${RESET}")
+go-test       = $(call quiet-command,${DOCKER_RUN_CMD} go test -v -count 1 -timeout 45m -parallel 1 ${1} | cat,"${YELLOW}[TEST] ${GREEN}${1}${RESET}")
 rm-command    = $(call quiet-command,rm -rf ${1},"${YELLOW}[CLEAN] ${GREEN}${1}${RESET}")

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Most basic usage just setting required arguments:
 
 ```hcl
 module "terraform-aws-vpc" {
-  source  = "git@github.com:mineiros-io/terraform-aws-vpc.git?ref=v0.6.0"
+  source  = "mineiros-io/vpc/aws"
+  version = "~> 0.7.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -386,13 +386,20 @@ environments by deploying a single NAT Gateway (`single`).
   through the same set of NAT Gateways.
   Possible modes are `none`, `single`, or `one_per_az`. Choose
 
-  - `none` to create no NAT Gateways at all (use for debugging only),
-  - `single` to create a single NAT Gateway inside the first defined
+  - `"none"` to create no NAT Gateways at all (use for debugging only),
+  - `"single"` to create a single NAT Gateway inside the first defined
   Public Subnet, or
-  - `one_per_az` to create one NAT Gateway inside the first Public
+  - `"one_per_az"` to create one NAT Gateway inside the first Public
   Subnet in each Availability Zone.
 
   Default is `"single"`.
+
+- [**`nat_gateway_single_mode_zone`**](#var-nat_gateway_single_mode_zone): *(Optional `string`)*<a name="var-nat_gateway_single_mode_zone"></a>
+
+  Define the zone (short name) of the NAT gateway when nat_gateway_mode is "single" (e.g. "a", "b", or "c").
+  The AWS region will be added as a prefix.
+
+  Default is `"a random zone"`.
 
 - [**`nat_gateway_tags`**](#var-nat_gateway_tags): *(Optional `map(string)`)*<a name="var-nat_gateway_tags"></a>
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   ```hcl
   {
-    Name                           = var.vpc_name
-    "mineiros-io/aws/vpc/vpc-name" = var.vpc_name
+    Name                           = "{vpc_name}"
+    "mineiros-io/aws/vpc/vpc-name" = "{vpc_name}"
   }
   ```
 
@@ -306,11 +306,11 @@ See [variables.tf] and [examples/] for details and use-cases.
 
     ```hcl
     {
-      Name                               = "{var.vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
-      "mineiros-io/aws/vpc/vpc-name"     = var.vpc_name
-      "mineiros-io/aws/vpc/subnet-name"  = "{var.vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
-      "mineiros-io/aws/vpc/subnet-group" = subnet.group
-      "mineiros-io/aws/vpc/subnet-class" = subnet.class
+      Name                               = "{vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
+      "mineiros-io/aws/vpc/vpc-name"     = "{vpc_name}"
+      "mineiros-io/aws/vpc/subnet-name"  = "{vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
+      "mineiros-io/aws/vpc/subnet-group" = "{subnet.group}"
+      "mineiros-io/aws/vpc/subnet-class" = "{subnet.class}"
     }
     ```
 
@@ -354,9 +354,9 @@ See [variables.tf] and [examples/] for details and use-cases.
 
   ```hcl
   {
-    Name                           = var.vpc_name
-    "mineiros-io/aws/vpc/vpc-name" = var.vpc_name
-    "mineiros-io/aws/vpc/igw-name" = var.vpc_name
+    Name                           = "{vpc_name}"
+    "mineiros-io/aws/vpc/vpc-name" = "{vpc_name}"
+    "mineiros-io/aws/vpc/igw-name" = "{vpc_name}"
   }
   ```
 
@@ -403,9 +403,9 @@ environments by deploying a single NAT Gateway (`single`).
 
   ```hcl
   {
-    Name                             = "{var.vpc_name}-{each.key}"
-    "mineiros-io/aws/vpc/vpc-name"   = var.vpc_name
-    "mineiros-io/aws/vpc/natgw-name" = "{var.vpc_name}-{each.key}"
+    Name                             = "{vpc_name}-{zone}"
+    "mineiros-io/aws/vpc/vpc-name"   = "{vpc_name}"
+    "mineiros-io/aws/vpc/natgw-name" = "{vpc_name}-{zone}"
   }
   ```
 
@@ -421,10 +421,10 @@ environments by deploying a single NAT Gateway (`single`).
 
   ```hcl
   {
-    Name                             = "{var.vpc_name}-nat-private-{each.key}"
-    "mineiros-io/aws/vpc/vpc-name"   = var.vpc_name
-    "mineiros-io/aws/vpc/natgw-name" = "{var.vpc_name}-{each.key}"
-    "mineiros-io/aws/vpc/eip-name"   = "{var.vpc_name}-nat-private-{each.key}"
+    Name                             = "{vpc_name}-nat-private-{zone}"
+    "mineiros-io/aws/vpc/vpc-name"   = "{vpc_name}"
+    "mineiros-io/aws/vpc/natgw-name" = "{vpc_name}-{zone}"
+    "mineiros-io/aws/vpc/eip-name"   = "{vpc_name}-nat-private-{zone}"
   }
   ```
 
@@ -447,9 +447,9 @@ environments by deploying a single NAT Gateway (`single`).
 
   ```hcl
   {
-    Name                                   = "{var.vpc_name}-public-{each.key}"
-    "mineiros-io/aws/vpc/vpc-name"         = var.vpc_name
-    "mineiros-io/aws/vpc/routetable-name"  = "{var.vpc_name}-public-{each.key}"
+    Name                                   = "{vpc_name}-public-{group}"
+    "mineiros-io/aws/vpc/vpc-name"         = "{vpc_name}"
+    "mineiros-io/aws/vpc/routetable-name"  = "{vpc_name}-public-{group}"
     "mineiros-io/aws/vpc/routetable-class" = "public"
   }
   ```
@@ -465,9 +465,9 @@ environments by deploying a single NAT Gateway (`single`).
 
   ```hcl
   {
-    Name                                   = "{var.vpc_name}-private-{each.key}"
-    "mineiros-io/aws/vpc/vpc-name"         = var.vpc_name
-    "mineiros-io/aws/vpc/routetable-name"  = "{var.vpc_name}-private-{each.key}"
+    Name                                   = "{vpc_name}-private-{group}-{zone}"
+    "mineiros-io/aws/vpc/vpc-name"         = "{vpc_name}"
+    "mineiros-io/aws/vpc/routetable-name"  = "{vpc_name}-private-{group}-{zone}"
     "mineiros-io/aws/vpc/routetable-class" = "private"
   }
   ```
@@ -483,9 +483,9 @@ environments by deploying a single NAT Gateway (`single`).
 
   ```hcl
   {
-    Name                                   = "{var.vpc_name}-intra-{each.key}"
-    "mineiros-io/aws/vpc/vpc-name"         = var.vpc_name
-    "mineiros-io/aws/vpc/routetable-name"  = "{var.vpc_name}-intra-{each.key}"
+    Name                                   = "{vpc_name}-intra-{group}"
+    "mineiros-io/aws/vpc/vpc-name"         = "{vpc_name}"
+    "mineiros-io/aws/vpc/routetable-name"  = "{vpc_name}-intra-{group}"
     "mineiros-io/aws/vpc/routetable-class" = "intra"
   }
   ```

--- a/README.md
+++ b/README.md
@@ -401,6 +401,13 @@ environments by deploying a single NAT Gateway (`single`).
 
   Default is `"a random zone"`.
 
+- [**`nat_gateway_eip_allocation_ids`**](#var-nat_gateway_eip_allocation_ids): *(Optional `map(string)`)*<a name="var-nat_gateway_eip_allocation_ids"></a>
+
+  A map of EIP allocation ids to use for nat gateways keyed by short zone name (e.g. "a", "b", or "c").
+  If set no EIPs will be created by the module. If unset, the module will create the needed number of EIPs.
+
+  Default is `{}`.
+
 - [**`nat_gateway_tags`**](#var-nat_gateway_tags): *(Optional `map(string)`)*<a name="var-nat_gateway_tags"></a>
 
   A map of tags to apply to the created NAT Gateways.

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -452,11 +452,20 @@ section {
             through the same set of NAT Gateways.
             Possible modes are `none`, `single`, or `one_per_az`. Choose
 
-            - `none` to create no NAT Gateways at all (use for debugging only),
-            - `single` to create a single NAT Gateway inside the first defined
+            - `"none"` to create no NAT Gateways at all (use for debugging only),
+            - `"single"` to create a single NAT Gateway inside the first defined
             Public Subnet, or
-            - `one_per_az` to create one NAT Gateway inside the first Public
+            - `"one_per_az"` to create one NAT Gateway inside the first Public
             Subnet in each Availability Zone.
+          END
+        }
+
+        variable "nat_gateway_single_mode_zone" {
+          type        = string
+          default     = "a random zone"
+          description = <<-END
+            Define the zone (short name) of the NAT gateway when nat_gateway_mode is "single" (e.g. "a", "b", or "c").
+            The AWS region will be added as a prefix.
           END
         }
 

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -469,6 +469,15 @@ section {
           END
         }
 
+        variable "nat_gateway_eip_allocation_ids" {
+          type        = map(string)
+          description = <<-END
+            A map of EIP allocation ids to use for nat gateways keyed by short zone name (e.g. "a", "b", or "c").
+            If set no EIPs will be created by the module. If unset, the module will create the needed number of EIPs.
+          END
+          default     = {}
+        }
+
         variable "nat_gateway_tags" {
           type        = map(string)
           default     = {}

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -78,7 +78,8 @@ section {
 
       ```hcl
       module "terraform-aws-vpc" {
-        source  = "git@github.com:mineiros-io/terraform-aws-vpc.git?ref=v0.6.0"
+        source  = "mineiros-io/vpc/aws"
+        version = "~> 0.7.0"
       }
       ```
     END

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -178,8 +178,8 @@ section {
           END
           readme_example = <<-END
             {
-              Name                           = var.vpc_name
-              "mineiros-io/aws/vpc/vpc-name" = var.vpc_name
+              Name                           = "{vpc_name}"
+              "mineiros-io/aws/vpc/vpc-name" = "{vpc_name}"
             }
           END
         }
@@ -354,11 +354,11 @@ section {
 
               ```hcl
               {
-                Name                               = "{var.vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
-                "mineiros-io/aws/vpc/vpc-name"     = var.vpc_name
-                "mineiros-io/aws/vpc/subnet-name"  = "{var.vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
-                "mineiros-io/aws/vpc/subnet-group" = subnet.group
-                "mineiros-io/aws/vpc/subnet-class" = subnet.class
+                Name                               = "{vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
+                "mineiros-io/aws/vpc/vpc-name"     = "{vpc_name}"
+                "mineiros-io/aws/vpc/subnet-name"  = "{vpc_name}-{subnet.group}-{subnet.class}-{az}-{idx}"
+                "mineiros-io/aws/vpc/subnet-group" = "{subnet.group}"
+                "mineiros-io/aws/vpc/subnet-class" = "{subnet.class}"
               }
               ```
             END
@@ -415,9 +415,9 @@ section {
 
             ```hcl
             {
-              Name                           = var.vpc_name
-              "mineiros-io/aws/vpc/vpc-name" = var.vpc_name
-              "mineiros-io/aws/vpc/igw-name" = var.vpc_name
+              Name                           = "{vpc_name}"
+              "mineiros-io/aws/vpc/vpc-name" = "{vpc_name}"
+              "mineiros-io/aws/vpc/igw-name" = "{vpc_name}"
             }
             ```
           END
@@ -471,9 +471,9 @@ section {
 
             ```hcl
             {
-              Name                             = "{var.vpc_name}-{each.key}"
-              "mineiros-io/aws/vpc/vpc-name"   = var.vpc_name
-              "mineiros-io/aws/vpc/natgw-name" = "{var.vpc_name}-{each.key}"
+              Name                             = "{vpc_name}-{zone}"
+              "mineiros-io/aws/vpc/vpc-name"   = "{vpc_name}"
+              "mineiros-io/aws/vpc/natgw-name" = "{vpc_name}-{zone}"
             }
             ```
           END
@@ -491,10 +491,10 @@ section {
 
             ```hcl
             {
-              Name                             = "{var.vpc_name}-nat-private-{each.key}"
-              "mineiros-io/aws/vpc/vpc-name"   = var.vpc_name
-              "mineiros-io/aws/vpc/natgw-name" = "{var.vpc_name}-{each.key}"
-              "mineiros-io/aws/vpc/eip-name"   = "{var.vpc_name}-nat-private-{each.key}"
+              Name                             = "{vpc_name}-nat-private-{zone}"
+              "mineiros-io/aws/vpc/vpc-name"   = "{vpc_name}"
+              "mineiros-io/aws/vpc/natgw-name" = "{vpc_name}-{zone}"
+              "mineiros-io/aws/vpc/eip-name"   = "{vpc_name}-nat-private-{zone}"
             }
             ```
           END
@@ -523,9 +523,9 @@ section {
 
             ```hcl
             {
-              Name                                   = "{var.vpc_name}-public-{each.key}"
-              "mineiros-io/aws/vpc/vpc-name"         = var.vpc_name
-              "mineiros-io/aws/vpc/routetable-name"  = "{var.vpc_name}-public-{each.key}"
+              Name                                   = "{vpc_name}-public-{group}"
+              "mineiros-io/aws/vpc/vpc-name"         = "{vpc_name}"
+              "mineiros-io/aws/vpc/routetable-name"  = "{vpc_name}-public-{group}"
               "mineiros-io/aws/vpc/routetable-class" = "public"
             }
             ```
@@ -543,9 +543,9 @@ section {
 
             ```hcl
             {
-              Name                                   = "{var.vpc_name}-private-{each.key}"
-              "mineiros-io/aws/vpc/vpc-name"         = var.vpc_name
-              "mineiros-io/aws/vpc/routetable-name"  = "{var.vpc_name}-private-{each.key}"
+              Name                                   = "{vpc_name}-private-{group}-{zone}"
+              "mineiros-io/aws/vpc/vpc-name"         = "{vpc_name}"
+              "mineiros-io/aws/vpc/routetable-name"  = "{vpc_name}-private-{group}-{zone}"
               "mineiros-io/aws/vpc/routetable-class" = "private"
             }
             ```
@@ -563,9 +563,9 @@ section {
 
             ```hcl
             {
-              Name                                   = "{var.vpc_name}-intra-{each.key}"
-              "mineiros-io/aws/vpc/vpc-name"         = var.vpc_name
-              "mineiros-io/aws/vpc/routetable-name"  = "{var.vpc_name}-intra-{each.key}"
+              Name                                   = "{vpc_name}-intra-{group}"
+              "mineiros-io/aws/vpc/vpc-name"         = "{vpc_name}"
+              "mineiros-io/aws/vpc/routetable-name"  = "{vpc_name}-intra-{group}"
               "mineiros-io/aws/vpc/routetable-class" = "intra"
             }
             ```

--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -8,7 +8,7 @@ locals {
 
 module "vpc" {
   source  = "mineiros-io/vpc/aws"
-  version = "~> 0.6.0"
+  version = "~> 0.7.0"
 
   module_enabled = true
 

--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -21,6 +21,8 @@ module "vpc" {
   # - "one_per_az" to create a NAT gateway per availability zone that has a private subnet. This needs a public subnets in the same AZs.
   nat_gateway_mode = "single"
 
+  nat_gateway_single_mode_zone = "a"
+
   subnets = [
     {
       # define a group name for the subnets. This can be any string. Default is "main".

--- a/private_routing.tf
+++ b/private_routing.tf
@@ -35,10 +35,12 @@ locals {
     for az in local.missing_public_subnet_azs[var.nat_gateway_mode] : "Missing public subnet in az" => local.public_subnets_by_az[az]
   }
 
+  nat_gateway_single_zones = var.nat_gateway_single_mode_zone != null ? ["${local.region}-${var.nat_gateway_single_mode_zone}"] : try([local.matching_azs[0]], [])
+
   matching_azs = sort(setintersection(local.public_azs, local.private_azs))
   nat_azs = {
     one_per_az = local.matching_azs
-    single     = try([local.matching_azs[0]], [])
+    single     = local.nat_gateway_single_zones
     none       = []
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,12 @@ variable "nat_gateway_single_mode_zone" {
   default     = null
 }
 
+variable "nat_gateway_eip_allocation_ids" {
+  description = "(Optional) A map of EIP allocation ids to use for nat gateways keyed by short zone name (e.g. \"a\", \"b\", or \"c\")."
+  type        = map(string)
+  default     = {}
+}
+
 variable "nat_gateway_tags" {
   description = "(Optional) A map of tags to apply to the created NAT Gateways. Default is {}."
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,12 @@ variable "nat_gateway_mode" {
   default     = "single"
 }
 
+variable "nat_gateway_single_mode_zone" {
+  description = "(Optional) Define the zone (short name) of the NAT gateway when nat_gateway_mode is \"single\" (e.g. \"a\", \"b\", or \"c\"). The AWS region will be added as a prefix. Defaults to a random zone."
+  type        = string
+  default     = null
+}
+
 variable "nat_gateway_tags" {
   description = "(Optional) A map of tags to apply to the created NAT Gateways. Default is {}."
   type        = map(string)


### PR DESCRIPTION
Allow to bring your own NAT gateway EIPs.

This is a all-or-none implementation so the user has to bring at least one EIP for each to be created NAT gateway.

The current tests just ensure backward compatibility.

we did not add tests to actually bring your own or to switch in a later state. We will need to have a better test set up for such tests first. to also test changes over time n a better way.


